### PR TITLE
SAD-8 Improved the getModuleViewDetails method algorithm to reduce the waiting time

### DIFF
--- a/app/js/moduleView/viewModuleDetails.html
+++ b/app/js/moduleView/viewModuleDetails.html
@@ -128,27 +128,26 @@
                 </tbody>
             </table>
 
-            <h2> Aware of Modules</h2>
+            <h2> Required Modules</h2>
             <div class="modal-body">
                 <ul class="list-group">
-                    <li class="list-group-item" ng-repeat="class1 in moduleViewRequiredModules.awareOfModules">
-                        <i class="icon-exclamation-sign"> </i> <a href="#/module-show/{{class1[1]}} ">{{class1[0]}}</a>
+                    <li class="list-group-item" ng-repeat="module in moduleViewRequiredModules.requiredModules">
+                        <i class="icon-exclamation-sign"> </i> <a href="#/module-show/{{module.uuid}} ">{{module.display}}</a>
                     </li>
-                    <div class="alert alert-info" ng-hide="moduleViewRequiredModules.awareOfModules.length">
-                        There are no aware of modules.
+                    <div class="alert alert-info" ng-if="moduleViewRequiredModules.requiredModules.length <= 0">
+                        There are no required modules.
                     </div>
                 </ul>
             </div>
 
-
-            <h2> Required Modules</h2>
+            <h2> Aware of Modules (Optional Required Modules) </h2>
             <div class="modal-body">
                 <ul class="list-group">
-                    <li class="list-group-item" ng-repeat="class2 in moduleViewRequiredModules.requiredModules">
-                        <i class="icon-exclamation-sign"> </i> <a href="#/module-show/{{class2[1]}} ">{{class2[0]}}</a>
+                    <li class="list-group-item" ng-repeat="module in moduleViewAwareOfModules.awareModules">
+                        <i class="icon-exclamation-sign"> </i> <a href="#/module-show/{{module.uuid}} ">{{module.display}}</a>
                     </li>
-                    <div class="alert alert-info" ng-hide="moduleViewRequiredModules.requiredModules.length">
-                        There are no required modules.
+                    <div class="alert alert-info" ng-if="moduleViewAwareOfModules.awareModules.length <= 0">
+                        There are no aware of modules.
                     </div>
                 </ul>
             </div>
@@ -156,10 +155,10 @@
             <h2> Dependent Modules on {{ModuleViewData.name}}</h2>
             <div class="modal-body">
                 <ul class="list-group">
-                    <li class="list-group-item" ng-repeat="class3 in DependentModuleList">
-                        <i class="icon-exclamation-sign"> </i> <a href="#/module-show/{{class3[1]}} ">{{class3[0]}}</a>
+                    <li class="list-group-item" ng-repeat="module in moduleViewDependentModules.dependentModules">
+                        <i class="icon-exclamation-sign"> </i> <a href="#/module-show/{{module.uuid}} ">{{module.display}}</a>
                     </li>
-                    <div class="alert alert-info" ng-hide="DependentModuleList.length">
+                    <div class="alert alert-info" ng-if="moduleViewDependentModules.dependentModules.length <= 0">
                         There are no modules which depend on this module.
                     </div>
                 </ul>
@@ -276,7 +275,7 @@
                     </ul>
                 </div>
                 <div class="modal-footer">
-                    <button class=" btn-danger" ng-click="StopModule(stopConfirmModuleData.uuid,'MODULEDETAILS')"
+                    <button class="btn btn-danger" ng-click="StopModule(stopConfirmModuleData.uuid,'MODULEDETAILS')"
                             data-dismiss="modal"><i class="icon-ok"> </i> Yes
                     </button>
                     <button class=" btn-secondary" data-dismiss="modal"><i class="icon-remove"> </i> No</button>


### PR DESCRIPTION
Issue : [SAD-8](https://issues.openmrs.org/browse/SAD-8)

This PR contains these following enhancement to reduce the user waiting time to get the whole module view information, 

1. Before the actual method, It will get all module data from the backend and create a temporary JSON data structure.
2. Loop for aware of module list in the selected module and check whether that aware of module package name exists in the temporary JSON structure. if exist then fetch the required information from that moduleData.
3. Loop for required modules list in the selected module and check whether that required of module package name exists in the temporary JSON structure. if exist then fetch the required information from that moduleData.
4. Loop for all modules again and get their required modules list. If this selected module is inside that list, then mark that module as a dependent module for this selected module.

Existing getModuleViewDetails() method used (x+y+1) REST requests to the backend and altogether 5 loops to get the required information for the view. So here, the method will only use one REST request to the backend and three loops to get the required information for the view. Hope this modification will reduce much waiting time for the users. 
