### PR TITLE
SAD-35: Added support for non-standard openmrs instance paths

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -18,8 +18,8 @@
     <!-- OpenMRS Header-->
           <header ng-controller="mainHomeCtrl">
         <div class="logo">
-            <a href="/openmrs/referenceapplication/home.page">
-                <img src="/openmrs/ms/uiframework/resource/uicommons/images/logo/openmrs-with-title-small.png">
+            <a href="../../referenceapplication/home.page">
+                <img src="../../ms/uiframework/resource/uicommons/images/logo/openmrs-with-title-small.png">
             </a>
         </div>
         <ul class="user-options" data-ng-init="getOpenMRSSession()">
@@ -31,7 +31,7 @@
                     <i class="icon-caret-down link" style="font-size: 0.7em;"></i>
                 </a>
               <div class="dropdown-menu" aria-labelledby="dropdownMenu3">
-                    <a href="/openmrs/adminui/myaccount/myAccount.page">
+                    <a href="../../adminui/myaccount/myAccount.page">
                 <button class="dropdown-item dropdown-item-OpenMRSheader" type="button" >My Account</button>
                   </a>  
               </div>  
@@ -49,7 +49,7 @@
               </div>  
             </li>
             <li class="logout" >
-                <a href="/openmrs/appui/header/logout.action?successUrl=openmrs">
+                <a href="../../appui/header/logout.action?successUrl={{getLogoutSuccessPath()}}">
                     Logout
                     <i class="icon-signout small"></i>
                 </a>
@@ -62,7 +62,7 @@
     <!--OpenMRS breadcrumbs-->
     <ul id="breadcrumbs" ng-controller="breadCrumbCtrl" >
         <li>
-            <a href="/openmrs">
+            <a href="../../">
             <i class="icon-home small"></i>
             </a> 
         </li>

--- a/app/js/main/mainController.js
+++ b/app/js/main/mainController.js
@@ -59,6 +59,12 @@ mainControllerModule.controller('mainHomeCtrl', ['$scope','$http','OWARoutesUtil
                 logger.error("Could not fetch the OpenMRS Session information from the server", data);
             });
         }
+
+        $scope.getLogoutSuccessPath = function() {
+            var openMrsUrl = OWARoutesUtil.getOpenmrsUrl();
+            logoutSuccessPath = openMrsUrl.substring(openMrsUrl.lastIndexOf('/') + 1);
+            return logoutSuccessPath;
+        }
     }]);
 
 mainControllerModule.controller('breadCrumbCtrl', ['$scope','$rootScope', function($scope,$rootScope){

--- a/app/js/moduleUpload/uploadModuleNormal.html
+++ b/app/js/moduleUpload/uploadModuleNormal.html
@@ -4,7 +4,7 @@
     <br/>
 
     <form name="classForm" enctype="multipart/form-data" method="post"
-          action="http://localhost:8080/openmrs/ws/rest/v1/module/?">
+          action="../../ws/rest/v1/module/?">
         <table>
             <tbody>
             <tr>

--- a/app/js/route/openMRSRoute.js
+++ b/app/js/route/openMRSRoute.js
@@ -8,16 +8,8 @@ OWARoutes
              */
             getOpenmrsUrl: function () {
                 var location = window.location.toString();
-                var serverLocation = location.substring(0, location.indexOf('/owa/')); // http://localhost:8080/openmrs/server1
-                var last_string = serverLocation.substring(serverLocation.lastIndexOf('/') + 1, serverLocation.length).toLowerCase(); // server1
-
-                var finallocation = serverLocation;
-                var isOpenMRS = last_string.indexOf('openmrs');
-
-                if (isOpenMRS < 0) {
-                    finallocation = serverLocation.substring(0, serverLocation.lastIndexOf('/')); // http://localhost:8080/openmrs
-                }
-                return finallocation;
+                var serverLocation = location.substring(0, location.indexOf('/owa/')); // http://localhost:8080/openmrs
+                return serverLocation;
             }
         }
     }]);


### PR DESCRIPTION
## Description of what I changed
I've addressed the problem of non-relative, hardcoded paths in SysAdmin module with a similiar solution to what other OWAs use (`../../` path beginning).

I've also simplified the `OWARoutesUtil.getOpenmrsUrl()` function because it was unecessarily complex, and didn't support openmrs instances with other path beginning than `openmrs` (using server name not containing `openmrs` caused that the result of the function was just the server address).

I'm attaching a JSFiddle showing an example usage of the new code: https://jsfiddle.net/a0b1o76h/2/
## Issue I worked on
see https://issues.openmrs.org/browse/SAD-35

## Checklist: I completed these to help reviewers :)
- [x] My pull request only contains **ONE single commit**
- [x] My IDE is configured to follow the [**code style**](https://wiki.openmrs.org/display/docs/Java+Conventions) of this project.
- [x] I have **added tests** to cover my changes. (If you refactored
  existing code that was well tested you do not have to add tests)
- [x] I ran `mvn clean package` right before creating this pull request and
  added all formatting changes to my commit.
- [x] All new and existing **tests passed**.
- [x] My pull request is **based on the latest changes** of the master branch.

