### PR TITLE
SAD-26: Removed sensitive data from text copied to clipboard and fixed module count number

### DIFF
--- a/app/js/systeminfo/systemInfoController.js
+++ b/app/js/systeminfo/systemInfoController.js
@@ -19,7 +19,7 @@ SystemInfoControllerModule.controller('systeminfoCtrl', ['$scope','$http','OWARo
                 logTextDocument+=key + " : " + value + "\n";
             }
         });
-        logTextDocument +="\nModule Information (" + $scope.SystemInfoImportantContent['modules']['SystemInfo.Module.repositoryPath'] + ")\n----------------------------------------\n";
+        logTextDocument +="\nModule Information\n----------------------------------------\n";
         indexCount = 1;
         angular.forEach($scope.SystemInfoImportantContent['modules'], function(value, key) {
             if(key!='SystemInfo.Module.repositoryPath') {
@@ -131,7 +131,8 @@ SystemInfoControllerModule.controller('systeminfoCtrl', ['$scope','$http','OWARo
                     if (typeof(data.systemInfo["SystemInfo.title.moduleInformation"]) != "undefined")
                     {
                         $scope.moduleInformation = data.systemInfo["SystemInfo.title.moduleInformation"];
-                        $scope.SystemInfoImportantContent["Total Modules"] = keyCount($scope.moduleInformation);
+                        //minus 1 because it contains "SystemInfo.Module.repositoryPath" key too which is not a module
+                        $scope.SystemInfoImportantContent["Total Modules"] = keyCount($scope.moduleInformation) - 1;
                         $scope.SystemInfoImportantContent["modules"] =  $scope.moduleInformation;
                     }
                     else {


### PR DESCRIPTION
## Description of what I changed
I've removed the `modules` folder path from data copied to the clipboard (used to share with others when solving issues) - the reason is that this shouldn't contain any sensitive, instance-specific information (like it doesn't contain host name, connection url and other folder paths).

By the way, I've also fixed the total module count and added a explanation comment above.
## Issue I worked on
see https://issues.openmrs.org/browse/SAD-26

## Checklist: I completed these to help reviewers :)
- [x] My pull request only contains **ONE single commit**
- [x] My IDE is configured to follow the [**code style**](https://wiki.openmrs.org/display/docs/Java+Conventions) of this project.
- [x] I have **added tests** to cover my changes. (If you refactored
  existing code that was well tested you do not have to add tests)
- [x] All new and existing **tests passed**.
- [x] My pull request is **based on the latest changes** of the master branch.

  No? Unsure? -> execute command `git pull --rebase upstream master`

