### PR TITLE
Remove unecessary point from checklist of PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -30,11 +30,6 @@ see https://issues.openmrs.org/browse/SAD-
 
   No? -> write tests and add them to this commit `git add . && git commit --amend`
 
-- [ ] I ran `mvn clean package` right before creating this pull request and
-  added all formatting changes to my commit.
-
-  No? -> execute above command
-
 - [ ] All new and existing **tests passed**.
 
   No? -> figure out why and add the fix to your commit. It is your responsibility to make sure your code works.


### PR DESCRIPTION
I'm sorry, but what's the purpose of calling `mvn clean package` in this repo? 😀 

It doesn't contain any maven-related files here, and obviously this command fails (there's nothing to work with). Therefore I've decided to remove this sentence :)