### PR TITLE
SAD-36: Removed duplicated ngCopy call

### DIFF
--- a/app/js/systeminfo/systemInfoController.js
+++ b/app/js/systeminfo/systemInfoController.js
@@ -29,7 +29,7 @@ SystemInfoControllerModule.controller('systeminfoCtrl', ['$scope','$http','OWARo
         });
 
         $scope.copiedToClipboard = ngCopy(logTextDocument);
-        if(ngCopy(logTextDocument)) {
+        if($scope.copiedToClipboard) {
             $scope.copyToClipboardText = "Copied";
             $scope.copiedToClipboardIcon = "ok";
             $timeout(function(){ $scope.copyToClipboardText = "Copy System Info"; $scope.copiedToClipboardIcon = "copy";  }, 3000);  


### PR DESCRIPTION
## Description of what I changed
I've removed the duplicated `ngCopy` method call, which seems to create unecessary performance overhead.

## Issue I worked on
see https://issues.openmrs.org/browse/SAD-36

## Checklist: I completed these to help reviewers :)
- [x] My pull request only contains **ONE single commit**
- [x] My IDE is configured to follow the [**code style**](https://wiki.openmrs.org/display/docs/Java+Conventions) of this project.
- [x] I have **added tests** to cover my changes. (If you refactored
  existing code that was well tested you do not have to add tests)
- [x] I ran `gulp` right before creating this pull request to verify if the project is building properly.
- [x] All new and existing **tests passed**.
- [x] My pull request is **based on the latest changes** of the master branch.
